### PR TITLE
Fix ICEBERG forward prediction on pip-install / CPU / pytorch_lightning 2.x

### DIFF
--- a/src/ms_pred/dag_pred/iceberg_elucidation.py
+++ b/src/ms_pred/dag_pred/iceberg_elucidation.py
@@ -273,7 +273,10 @@ def iceberg_prediction(
         df.to_csv(save_dir / f'cands_df_{exp_name}.tsv', sep='\t', index=False)
 
         # run iceberg to generate in-silico spectrum
-        cmd = (f'''{python_path} src/ms_pred/dag_pred/predict_smis.py \\
+        # Resolve predict_smis.py relative to this package, not the current working
+        # directory, so it also works when ms_pred is pip-installed (no src/ checkout).
+        predict_script = Path(__file__).resolve().parent / "predict_smis.py"
+        cmd = (f'''{python_path} {predict_script} \\
                --batch-size {batch_size} \\
                --num-workers {num_workers} \\
                --dataset-labels {save_dir / f"cands_df_{exp_name}.tsv"} \\

--- a/src/ms_pred/dag_pred/predict_smis.py
+++ b/src/ms_pred/dag_pred/predict_smis.py
@@ -78,7 +78,7 @@ def predict():
     save_dir = Path(kwargs["save_dir"])
     debug = kwargs["debug"]
     common.setup_logger(save_dir, log_name="joint_pred.log", debug=debug)
-    pl.utilities.seed.seed_everything(kwargs.get("seed"))
+    pl.seed_everything(kwargs.get("seed"))
 
     # Dump args
     yaml_args = yaml.dump(kwargs)
@@ -195,7 +195,8 @@ def predict():
             else:
                 device = "cpu"
             model.to(device)
-            torch.cuda.set_device(gpu_id) # avoids error in pe_embedding under multithreading. 
+            if gpu and avail_gpu_num > 0:
+                torch.cuda.set_device(gpu_id)  # avoids error in pe_embedding under multithreading
 
             # for batch in batched_entries:
             smis, spec_names, colli_eng_vals, adducts, instruments, precursor_mzs, h5_names = list(zip(*batch))


### PR DESCRIPTION
## Summary

Three small, backward-compatible fixes so ICEBERG **forward prediction**
(`iceberg_prediction()` → `dag_pred/predict_smis.py`) runs end-to-end when `ms_pred` is
**pip-installed**, on **CPU**, and with **pytorch_lightning ≥ 2.0**. None of them change
behavior for an editable checkout / GPU / PL 1.x.

### 1. `dag_pred/iceberg_elucidation.py` — resolve `predict_smis.py` relative to the package
`iceberg_prediction()` builds the subprocess with a **cwd-relative** path:
```python
cmd = f'''{python_path} src/ms_pred/dag_pred/predict_smis.py ...'''
```
That only resolves when run from the repo root. On a pip install there is no `src/`, so the
subprocess fails (`can't open file '.../src/ms_pred/dag_pred/predict_smis.py'`) and
`load_pred_spec` then raises on the missing `preds.hdf5`. Fixed by locating the script via
`Path(__file__).resolve().parent / "predict_smis.py"` (the two files live side by side).

### 2. `dag_pred/predict_smis.py` — `pl.seed_everything`
`pytorch_lightning.utilities.seed.seed_everything` was removed in PL 2.0
(`AttributeError: module 'pytorch_lightning.utilities.seed' has no attribute 'seed_everything'`).
`pl.seed_everything` is the public API and exists in both PL 1.x and 2.x.

### 3. `dag_pred/predict_smis.py` — guard `torch.cuda.set_device` on CPU
In `producer_func`, `torch.cuda.set_device(gpu_id)` runs unconditionally, but `gpu_id` is
only assigned in the GPU branch — on CPU this raises `NameError` (and there is no CUDA
device to select). Guarded with `if gpu and avail_gpu_num > 0:`.

## How these surfaced
Predicting MS/MS from SMILES with the public MassSpecGym checkpoints on macOS (CPU) with
pytorch_lightning 2.6.5; each fix revealed the next.

## Testing
After all three, `iceberg_prediction(...)` runs end-to-end on CPU and produces `preds.hdf5`
(verified by predicting glyphosate MS/MS for `[M-H]-` and `[M+H]+`).
